### PR TITLE
TT-209 문단별 입력에서 자음과 모음이 분리되는 오류 해결

### DIFF
--- a/lib/features/script_input/controller/script_input_controller.dart
+++ b/lib/features/script_input/controller/script_input_controller.dart
@@ -31,8 +31,6 @@ class ScriptInputCtr extends GetxController {
 
   void updateScript(int index, String newScript) {
     _script[index] = newScript;
-    script.value[index].text = _script[index];
-    script.value = script.value.toList();
   }
 
   void addParagraph() {


### PR DESCRIPTION
- 대본 문단별 입력(scriptInput)에서 텍스트 입력 시 자음과 모음이 분리되어 입력되는 문제가 있었음.
- TextField의 onChanged()에서 매번 컨트롤러의 text를 설정해서 발생한 문제였음.
- TextEditingController는 실시간으로 TextField의 변경사항을 저장하는 기능이 있기 때문에, 불필요하고 오류를 발생시키는 해당 부분의 코드를 제거하여 해결함.