### PR TITLE
TT-217 대본 주제 입력 api 결과 저장되지 않는 오류 해결

### DIFF
--- a/lib/features/common/models/theme_id_model.dart
+++ b/lib/features/common/models/theme_id_model.dart
@@ -5,7 +5,7 @@ part 'theme_id_model.g.dart';
 @JsonSerializable()
 class ThemeIdModel {
 
-  late final themeId;
+  late final int themeId;
 
   ThemeIdModel({required this.themeId});
 

--- a/lib/features/theme_input/controller/theme_input_controller.dart
+++ b/lib/features/theme_input/controller/theme_input_controller.dart
@@ -23,13 +23,12 @@ class ThemeInputCtr extends GetxController {
     }
     await LocalPracticeThemeStorage().setThemeText(_theme);
     final ThemeIdModel themeIdModel = await getThemeId(_theme ?? "");
-    await LocalPracticeThemeStorage().setThemeId(themeIdModel.themeId);
+    await LocalPracticeThemeStorage().setThemeId(themeIdModel.themeId.toString());
   }
 
   Future<ThemeIdModel> getThemeId(String theme) async {
     try {
       Dio dio = Dio();
-      //TODO LocalUserTokenStorage()에 접근할 때 동시성 문제 발생하지 않는지 궁금
       dio.interceptors.add(AuthTokenInjectInterceptor(localUserTokenStorage: LocalUserTokenStorage()));
       dio.interceptors.add(AuthTokenRefreshInterceptor(localDeviceUuidStorage: LocalDeviceUuidStorage(), localUserTokenStorage: LocalUserTokenStorage()));
       final remoteThemeSaveDataSource = RemoteThemeSaveDataSource(dio);


### PR DESCRIPTION
- ThemeIdModel의 themeId가 dynamic으로 명시적이지 않아서 실제 데이터가 int형으로 오는데 string형으로 생각하고 처리해서 오류가 발생했음. themeId의 타입을 int로 명시적으로 설정하고 int형에 필요한 처리를 넣어 해결함
