### PR TITLE
TT-219 Mock 파일 분리

### DIFF
--- a/lib/features/practice_history/controller/history_controller.dart
+++ b/lib/features/practice_history/controller/history_controller.dart
@@ -6,9 +6,9 @@ import 'package:swm_peech_flutter/features/common/data_source/local/local_user_t
 import 'package:swm_peech_flutter/features/common/dio_intercepter/auth_token_inject_interceptor.dart';
 import 'package:swm_peech_flutter/features/common/dio_intercepter/auth_token_refresh_intercepter.dart';
 import 'package:swm_peech_flutter/features/common/dio_intercepter/debug_interceptor.dart';
-import 'package:swm_peech_flutter/features/practice_history/data_source/local/history_major_data_source.dart';
-import 'package:swm_peech_flutter/features/practice_history/data_source/local/history_minor_data_source.dart';
-import 'package:swm_peech_flutter/features/practice_history/data_source/local/history_theme_data_source.dart';
+import 'package:swm_peech_flutter/features/practice_history/data_source/mock/mock_history_major_data_source.dart';
+import 'package:swm_peech_flutter/features/practice_history/data_source/mock/mock_history_minor_data_source.dart';
+import 'package:swm_peech_flutter/features/practice_history/data_source/mock/mock_history_theme_data_source.dart';
 import 'package:swm_peech_flutter/features/practice_history/data_source/remote/remote_major_list_data_source.dart';
 import 'package:swm_peech_flutter/features/practice_history/data_source/remote/remote_minor_list_data_source.dart';
 import 'package:swm_peech_flutter/features/practice_history/data_source/remote/remote_theme_list_data_source.dart';
@@ -23,7 +23,6 @@ class HistoryCtr extends GetxController {
   Rx<HistoryMajorListModel?> majorList = Rx<HistoryMajorListModel?>(null);
   Rx<HistoryMinorListModel?> minorList = Rx<HistoryMinorListModel?>(null);
 
-  final historyThemeDataSource = HistoryThemeDataSource();
 
   ScrollController themeScrollController = ScrollController();
   ScrollController majorScrollController = ScrollController();
@@ -54,6 +53,7 @@ class HistoryCtr extends GetxController {
   }
 
   void getThemeListTest() async {
+    final historyThemeDataSource = MockHistoryThemeDataSource();
     themeList.value = await historyThemeDataSource.getThemeListTest();
   }
 
@@ -78,7 +78,7 @@ class HistoryCtr extends GetxController {
   }
 
   void getMajorListTest() async {
-    final historyMajorDataSource = HistoryMajorDataSource();
+    final historyMajorDataSource = MockHistoryMajorDataSource();
     majorList.value = await historyMajorDataSource.getMajorListTest();
   }
 
@@ -102,7 +102,7 @@ class HistoryCtr extends GetxController {
   }
 
   void getMinorListTest() async {
-    final historyMinorDataSource = HistoryMinorDataSource();
+    final historyMinorDataSource = MockHistoryMinorDataSource();
     minorList.value = await historyMinorDataSource.getMinorListTest();
   }
 

--- a/lib/features/practice_history/data_source/mock/mock_history_major_data_source.dart
+++ b/lib/features/practice_history/data_source/mock/mock_history_major_data_source.dart
@@ -1,7 +1,7 @@
 import 'package:swm_peech_flutter/features/practice_history/model/history_major_list_model.dart';
 import 'package:swm_peech_flutter/features/practice_history/model/history_major_model.dart';
 
-class HistoryMajorDataSource {
+class MockHistoryMajorDataSource {
 
   Future<HistoryMajorListModel?> getMajorListTest() async {
     return HistoryMajorListModel(

--- a/lib/features/practice_history/data_source/mock/mock_history_minor_data_source.dart
+++ b/lib/features/practice_history/data_source/mock/mock_history_minor_data_source.dart
@@ -1,7 +1,7 @@
 import 'package:swm_peech_flutter/features/practice_history/model/history_minor_list_model.dart';
 import 'package:swm_peech_flutter/features/practice_history/model/history_minor_model.dart';
 
-class HistoryMinorDataSource {
+class MockHistoryMinorDataSource {
 
   Future<HistoryMinorListModel?> getMinorListTest() async {
     return HistoryMinorListModel(

--- a/lib/features/practice_history/data_source/mock/mock_history_theme_data_source.dart
+++ b/lib/features/practice_history/data_source/mock/mock_history_theme_data_source.dart
@@ -1,7 +1,7 @@
 import 'package:swm_peech_flutter/features/practice_history/model/history_theme_list_model.dart';
 import 'package:swm_peech_flutter/features/practice_history/model/history_theme_model.dart';
 
-class HistoryThemeDataSource {
+class MockHistoryThemeDataSource {
 
   Future<HistoryThemeListModel?> getThemeListTest() async {
     return HistoryThemeListModel(

--- a/lib/features/practice_result/controller/practice_result_controller.dart
+++ b/lib/features/practice_result/controller/practice_result_controller.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
-import 'package:swm_peech_flutter/features/practice_result/data_source/practice_rseult_data_source.dart';
+import 'package:swm_peech_flutter/features/practice_result/data_source/mock/mock_practice_rseult_data_source.dart';
 import 'package:swm_peech_flutter/features/practice_result/model/practice_result_model.dart';
 
 class PracticeResultCtr extends GetxController {
 
-  PracticeResultDataSource practiceResultDataSource = PracticeResultDataSource();
+  MockPracticeResultDataSource practiceResultDataSource = MockPracticeResultDataSource();
 
   List<PracticeResultModel>? _practiceResult; //데이터 받아오고, 요청 보낼때만 수정
   Rx<List<TextEditingController>?> practiceResult = Rx<List<TextEditingController>?>(null);

--- a/lib/features/practice_result/data_source/mock/mock_practice_rseult_data_source.dart
+++ b/lib/features/practice_result/data_source/mock/mock_practice_rseult_data_source.dart
@@ -1,6 +1,6 @@
 import 'package:swm_peech_flutter/features/practice_result/model/practice_result_model.dart';
 
-class PracticeResultDataSource {
+class MockPracticeResultDataSource {
 
   Future<List<PracticeResultModel>> getPracticeResultListTest() async {
     await Future.delayed(const Duration(seconds: 3));


### PR DESCRIPTION
- mock 클래스와 파일 이름 앞에 mock을 붙임
- mock 파일은 mock 폴더로 디렉토리를 구분함
