### PR TITLE
TT-229 토큰 null일 때 x로 보내기

### DIFF
--- a/lib/features/common/dio_intercepter/auth_token_inject_interceptor.dart
+++ b/lib/features/common/dio_intercepter/auth_token_inject_interceptor.dart
@@ -12,9 +12,9 @@ class AuthTokenInjectInterceptor extends Interceptor {
 
     final String? token = localUserTokenStorage.getUserToken();
 
-    options.headers.addAll({"authorization": "Bearer $token"});
+    options.headers.addAll({"authorization": "Bearer ${token ?? 'x'}"});
 
-    print("[REQ] [TokenInject] [${options.method}] [${options.path}] -> inject token [$token]");
+    print("[REQ] [TokenInject] [${options.method}] [${options.path}] -> inject token [${token ?? 'x'}]");
     return super.onRequest(options, handler);
   }
 


### PR DESCRIPTION
- 인증 토큰 null일 때 "Bearer null"가 아닌 "Bearer x"로 보내도록 수정