### PR TITLE
TT-231 발표 목록에서 path가 무조건 맨 위 주제 타이틀로 표시되는 오류 해결

### DIFF
--- a/lib/features/practice_history/controller/history_controller.dart
+++ b/lib/features/practice_history/controller/history_controller.dart
@@ -107,7 +107,8 @@ class HistoryCtr extends GetxController {
   }
 
   void clickThemeList(int index) {
-    historyPath.value.setTheme(themeList.value?.themes?[index].themeId ?? 0);
+    print("선택 테마: ${themeList.value?.themes?[index].themeId}");
+    historyPath.value.setTheme(themeList.value?.themes?[index].themeId);
     initMajorScrollController();
   }
 

--- a/lib/features/practice_history/widgets/history_path_view.dart
+++ b/lib/features/practice_history/widgets/history_path_view.dart
@@ -18,17 +18,17 @@ Widget historyPathView(HistoryCtr controller) {
           ),
           if(controller.historyPath.value.theme != null)
             historyPathUnit(
-                text: controller.themeList.value?.themes?[controller.historyPath.value.major ?? 0].themeTitle.toString() ?? 'unknown',
+                text: controller.themeList.value?.themes?.firstWhereOrNull((element) => element.themeId == controller.historyPath.value.theme)?.themeTitle.toString() ?? 'unknown',
                 onClick: () { controller.historyPath.value.setPrevPath(HistoryPathState.majorList); }
             ),
           if(controller.historyPath.value.major != null)
             historyPathUnit(
-                text: controller.majorList.value?.majorScripts?[controller.historyPath.value.major ?? 0].createdAt.toString() ?? 'unknown',
+                text: controller.majorList.value?.majorScripts?.firstWhereOrNull((element) => element.majorVersion == controller.historyPath.value.major)?.createdAt.toString() ?? 'unknown',
                 onClick: () { controller.historyPath.value.setPrevPath(HistoryPathState.minorList); }
             ),
           if(controller.historyPath.value.minor != null)
             historyPathUnit(
-                text: controller.minorList.value?.minorScripts?[controller.historyPath.value.minor ?? 0].createdAt.toString() ?? 'unknown',
+                text: controller.minorList.value?.minorScripts?.firstWhereOrNull((element) => element.minorVersion == controller.historyPath.value.minor)?.createdAt.toString() ?? 'unknown',
                 onClick: () {  }
             ),
         ],


### PR DESCRIPTION
- theme path표시를 theme id가 아닌 major id로 하고 있어서 생긴 오류였음. major가 아닌 theme id로 보여주도록 함.
- themeId로 path를 보여줄 때 일치하는 themeId의 요소를 찾고, 그 타이틀을 보여주는게 아닌 themeId로 인덱싱해서 보여주는 잠정적인 오류가 있었음. 이를 일치하는 themeId를 찾아서 보여주는 방식으로 바꿈.
