### PR TITLE
TT-248 History에서 system backbutton를 눌렀을 때 이전 path로 돌아가게 하기

### DIFF
--- a/lib/features/practice_history/view/history_screen.dart
+++ b/lib/features/practice_history/view/history_screen.dart
@@ -13,29 +13,38 @@ class HistoryScreen extends StatelessWidget {
 
     final controller = Get.find<HistoryCtr>();
 
-    return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(onPressed: () { controller.backButton(context); }, icon: const Icon(Icons.arrow_back_ios)),
-        title: const Text("발표 기록"),
-      ),
-      body: GetX<HistoryCtr>(
-        builder: (_) {
-          return Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Padding(
-                  padding: const EdgeInsets.all(15.0),
-                  child: historyPathView(controller)
-              ),
-              Expanded(
-                child: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: historyListView(context, controller)
-                ),
-              ),
-            ],
-          );
+    return PopScope(
+      canPop: false,
+      onPopInvoked: (didPop) async {
+        if(!didPop) {
+          controller.backButton(context);
+
         }
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          leading: IconButton(onPressed: () { controller.backButton(context); }, icon: const Icon(Icons.arrow_back_ios)),
+          title: const Text("발표 기록"),
+        ),
+        body: GetX<HistoryCtr>(
+          builder: (_) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                    padding: const EdgeInsets.all(15.0),
+                    child: historyPathView(controller)
+                ),
+                Expanded(
+                  child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: historyListView(context, controller)
+                  ),
+                ),
+              ],
+            );
+          }
+        ),
       ),
     );
   }


### PR DESCRIPTION
issue: #68 

구현 내용
---
발표 기록 페이지에서 시스템 백 버튼을 눌렀을 때 어느 경로에 있던 홈 화면으로 이동하는 것이 아니라, 이전 경로로 이동하고 이전 경로가 없는 경우에 홈으로 이동하도록 구현함.

기타
---
유저의 BackButton 행동 커스터마이징 하기

- ~~WillPopScope 클래스로 위젯을 감싸, 유저가 BackButton으로 뒤로 돌아가는 것을 막고 onWillPop 매게변수에 비동기 함수를 전달해 커스터마이징 할 수 있다.~~ → deprecated 되었다.
- **PopScope** 클래스를 사용할 수 있다.
    - **canPop**:
        - boolean값으로 기존 뒤로가기 키를 활성화(true)/비활성화(false) 할 수 있다.
    - **onPopInvoked:**
        - 화면을 pop하려는 시도가 있으면 실행된다. 만약 화면이 pop됬으면 boolean이 true로 전달되고, 아니면 false로 전달된다.
        - void Function(bool)값을 인자로 넘겨 뒤로가기 이벤트가 발생했을 때 실행할 함수를 커스터마이징 할 수 있다.
- 참고문서
    - https://api.flutter.dev/flutter/widgets/PopScope-class.html
    - [https://velog.io/@sue0-si/WillScope-deprecated-문제-해결-PopScope](https://velog.io/@sue0-si/WillScope-deprecated-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0-PopScope)