### PR TITLE
TT-196 음성 전송 및 연습 결과 api 연동

### DIFF
--- a/lib/features/common/constant/constants.dart
+++ b/lib/features/common/constant/constants.dart
@@ -1,3 +1,4 @@
 class Constants {
   static const int recodeLimitMilliTimes = 900000;
+  static const String recodingFileName = "audio_recording.aac";
 }

--- a/lib/features/common/utils/recoding_file_util.dart
+++ b/lib/features/common/utils/recoding_file_util.dart
@@ -1,0 +1,13 @@
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
+import 'package:swm_peech_flutter/features/common/constant/constants.dart';
+
+class RecodingFileUtil {
+  Future<String> getFilePath() async {
+    String fileName = Constants.recodingFileName;
+    Directory appDocDir = await getApplicationDocumentsDirectory();
+    String appDocPath = appDocDir.path;
+    String filePath = '$appDocPath/$fileName';
+    return filePath;
+  }
+}

--- a/lib/features/practice_result/controller/practice_result_controller.dart
+++ b/lib/features/practice_result/controller/practice_result_controller.dart
@@ -32,6 +32,7 @@ class PracticeResultCtr extends GetxController {
 
   Future<ParagraphListModel> postPracticeResult() async {
    try {
+     print('postPracticeResult() called');
      Dio dio = Dio();
      dio.interceptors.add(AuthTokenInjectInterceptor(localUserTokenStorage: LocalUserTokenStorage()));
      int themeId = int.parse(LocalPracticeThemeStorage().getThemeId() ?? '0');

--- a/lib/features/practice_result/controller/practice_result_controller.dart
+++ b/lib/features/practice_result/controller/practice_result_controller.dart
@@ -1,13 +1,19 @@
+import 'dart:io';
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
+import 'package:dio/dio.dart';
+import 'package:swm_peech_flutter/features/common/data_source/local/local_practice_theme_storage.dart';
+import 'package:swm_peech_flutter/features/common/data_source/local/local_script_storage.dart';
+import 'package:swm_peech_flutter/features/common/data_source/local/local_user_token_storage.dart';
+import 'package:swm_peech_flutter/features/common/dio_intercepter/auth_token_inject_interceptor.dart';
+import 'package:swm_peech_flutter/features/common/utils/recoding_file_util.dart';
 import 'package:swm_peech_flutter/features/practice_result/data_source/mock/mock_practice_rseult_data_source.dart';
+import 'package:swm_peech_flutter/features/practice_result/data_source/remote/remote_practice_result_data_source.dart';
 import 'package:swm_peech_flutter/features/practice_result/model/paragraph_list_model.dart';
 import 'package:swm_peech_flutter/features/practice_result/model/paragraph_model.dart';
 import 'package:swm_peech_flutter/features/practice_result/model/sentence_model.dart';
 
 class PracticeResultCtr extends GetxController {
-
-  MockPracticeResultDataSource practiceResultDataSource = MockPracticeResultDataSource();
 
   ParagraphListModel? _practiceResult; //데이터 받아오고, 요청 보낼때만 수정
   Rx<ParagraphListModel?> practiceResult = Rx<ParagraphListModel?>(null);
@@ -15,8 +21,37 @@ class PracticeResultCtr extends GetxController {
 
 
   void getPracticeResult() async {
-    _practiceResult = await practiceResultDataSource.getPracticeResultListTest();
+    _practiceResult = await postPracticeResult();
     practiceResult.value = ParagraphListModel(script: _practiceResult?.script);
+  }
+
+  Future<File> getRecodingFile() async {
+    String filePath = await RecodingFileUtil().getFilePath();
+    return File(filePath);
+  }
+
+  Future<ParagraphListModel> postPracticeResult() async {
+   try {
+     Dio dio = Dio();
+     dio.interceptors.add(AuthTokenInjectInterceptor(localUserTokenStorage: LocalUserTokenStorage()));
+     int themeId = int.parse(LocalPracticeThemeStorage().getThemeId() ?? '0');
+     int scriptId = LocalScriptStorage().getScriptId() ?? 0;
+     File voiceFile = await getRecodingFile();
+     RemotePracticeResultDataSource practiceResultDataSource = RemotePracticeResultDataSource(dio);
+     ParagraphListModel paragraphListModel = await practiceResultDataSource.getPracticeResultList(themeId, scriptId, voiceFile);
+     return paragraphListModel;
+   } on DioException catch(e) {
+     print("[postPracticeResult] DioException: [${e.response?.statusCode}] ${e.response?.data}");
+     rethrow;
+   } catch(e) {
+     print("[postPracticeResult] Exception: ${e}");
+     rethrow;
+   }
+  }
+
+  Future<ParagraphListModel> postPracticeResultTest() async {
+    MockPracticeResultDataSource practiceResultDataSource = MockPracticeResultDataSource();
+    return await practiceResultDataSource.getPracticeResultListTest();
   }
 
   @override

--- a/lib/features/practice_result/data_source/remote/remote_practice_result_data_source.dart
+++ b/lib/features/practice_result/data_source/remote/remote_practice_result_data_source.dart
@@ -11,5 +11,5 @@ abstract class RemotePracticeResultDataSource {
   factory RemotePracticeResultDataSource(Dio dio, {String baseUrl}) = _RemotePracticeResultDataSource;
 
   @POST("themes/{themeId}/scripts/{scriptId}/speech/script")
-  Future<ParagraphListModel> getPracticeResultList(@Path("themeId") int themeId, @Path("scriptId") int scriptId, @Part() File file);
+  Future<ParagraphListModel> getPracticeResultList(@Path("themeId") int themeId, @Path("scriptId") int scriptId, @Part(name: 'file') File file);
 }

--- a/lib/features/practice_result/data_source/remote/remote_practice_result_data_source.dart
+++ b/lib/features/practice_result/data_source/remote/remote_practice_result_data_source.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+import 'package:dio/dio.dart';
+import 'package:retrofit/http.dart';
+import 'package:retrofit/retrofit.dart';
+import 'package:swm_peech_flutter/features/practice_result/model/paragraph_list_model.dart';
+
+part 'remote_practice_result_data_source.g.dart';
+
+@RestApi(baseUrl: 'http://43.203.55.241:8080/api/vi/')
+abstract class RemotePracticeResultDataSource {
+  factory RemotePracticeResultDataSource(Dio dio, {String baseUrl}) = _RemotePracticeResultDataSource;
+
+  @POST("themes/{themeId}/scripts/{scriptId}")
+  Future<ParagraphListModel> getPracticeResultList(@Path("themeId") int themeId, @Path("scriptId") int scriptId, @Part() File file);
+}

--- a/lib/features/practice_result/data_source/remote/remote_practice_result_data_source.dart
+++ b/lib/features/practice_result/data_source/remote/remote_practice_result_data_source.dart
@@ -6,10 +6,10 @@ import 'package:swm_peech_flutter/features/practice_result/model/paragraph_list_
 
 part 'remote_practice_result_data_source.g.dart';
 
-@RestApi(baseUrl: 'http://43.203.55.241:8080/api/vi/')
+@RestApi(baseUrl: 'http://43.203.55.241:8080/api/v1/')
 abstract class RemotePracticeResultDataSource {
   factory RemotePracticeResultDataSource(Dio dio, {String baseUrl}) = _RemotePracticeResultDataSource;
 
-  @POST("themes/{themeId}/scripts/{scriptId}")
+  @POST("themes/{themeId}/scripts/{scriptId}/speech/script")
   Future<ParagraphListModel> getPracticeResultList(@Path("themeId") int themeId, @Path("scriptId") int scriptId, @Part() File file);
 }

--- a/lib/features/practice_result/view/practice_result_screen.dart
+++ b/lib/features/practice_result/view/practice_result_screen.dart
@@ -42,22 +42,47 @@ class PracticeResultScreen extends StatelessWidget {
                           itemBuilder: (BuildContext context, int index) {
                             return Column(
                               children: [
-                                if(index == 0)
-                                  GestureDetector(
-                                      onTap: () { controller.insertNewParagraph(0); },
+                                Stack(
+                                  alignment: Alignment.bottomLeft,
+                                  children: [
+                                    Row(
+                                      crossAxisAlignment: CrossAxisAlignment.end,
+                                      children: [
+                                        Text(
+                                          "${controller.practiceResult.value?.script?[index].time ?? "??:??:??"}",
+                                          style: const TextStyle(
+                                            fontSize: 14,
+                                            fontWeight: FontWeight.bold
+                                          ),
+                                        ),
+                                        const SizedBox(width: 2,),
+                                        const Text(
+                                          "측정",
+                                          style: TextStyle(
+                                            fontSize: 9,
+                                            color: Colors.grey,
+                                            fontWeight: FontWeight.bold
+                                          ),
+                                        )
+                                      ],
+                                    ),
+                                    GestureDetector(
+                                      onTap: () { controller.insertNewParagraph(index); },
                                       child: const Row(
                                         mainAxisAlignment: MainAxisAlignment.center,
-                                        children: [
-                                          Icon(Icons.add, color: Colors.grey,),
-                                          Text(
-                                            "문단 추가",
-                                            style: TextStyle(
+                                          children: [
+                                            Icon(Icons.add, color: Colors.grey,),
+                                            Text(
+                                              "문단 추가",
+                                              style: TextStyle(
                                                 color: Colors.grey
+                                              ),
                                             ),
-                                          ),
-                                        ],
-                                      )
-                                  ),
+                                          ],
+                                      ),
+                                    ),
+                                  ],
+                                ),
                                 Padding(
                                   padding: const EdgeInsets.symmetric(vertical: 4.0),
                                   child: Stack(
@@ -107,23 +132,23 @@ class PracticeResultScreen extends StatelessWidget {
                                     ],
                                   ),
                                 ),
-                                GestureDetector(
-                                    onTap: () { controller.insertNewParagraph(index + 1); },
-                                    child: const Row(
-                                      mainAxisAlignment: MainAxisAlignment.center,
-                                      children: [
-                                        Icon(Icons.add, color: Colors.grey,),
-                                        Text(
-                                          "문단 추가",
-                                          style: TextStyle(
-                                            color: Colors.grey
-                                          ),
-                                        ),
-                                      ],
-                                    )
-                                ),
                                 if(index + 1 == controller.practiceResult.value?.script?.length)
-                                  const SizedBox(height: 20,),
+                                  GestureDetector(
+                                      onTap: () { controller.insertNewParagraph(index + 1); },
+                                      child: const Row(
+                                        mainAxisAlignment: MainAxisAlignment.center,
+                                        children: [
+                                          Icon(Icons.add, color: Colors.grey,),
+                                          Text(
+                                            "문단 추가",
+                                            style: TextStyle(
+                                                color: Colors.grey
+                                            ),
+                                          ),
+                                        ],
+                                      )
+                                  ),
+
 
                               ],
                             );

--- a/lib/features/voice_recode/controller/voice_recode_controller.dart
+++ b/lib/features/voice_recode/controller/voice_recode_controller.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
-
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:flutter_sound/flutter_sound.dart';
-import 'package:swm_peech_flutter/features/common/constant/constant.dart';
+import 'package:swm_peech_flutter/features/common/constant/constants.dart';
 import 'package:swm_peech_flutter/features/common/data_source/local/local_script_storage.dart';
+import 'package:swm_peech_flutter/features/common/utils/recoding_file_util.dart';
 import 'package:swm_peech_flutter/features/voice_recode/model/practice_state.dart';
 
 class VoiceRecodeCtr extends GetxController {
@@ -14,7 +14,8 @@ class VoiceRecodeCtr extends GetxController {
   FlutterSoundPlayer? _player;
   Rx<bool> isRecording = false.obs;
   Rx<bool> isPlaying = false.obs;
-  final String _path = 'audio_recording.aac';
+
+  late final String _path;
   late final List<String>? script;
   ScrollController scriptScrollController = ScrollController();
   Rx<PracticeState> practiceState = PracticeState.BEFORETOSTART.obs;
@@ -24,8 +25,9 @@ class VoiceRecodeCtr extends GetxController {
   Timer? _timer;
 
   @override
-  void onInit() {
+  void onInit() async {
     script = LocalScriptStorage().getScriptContent();
+    _path = await RecodingFileUtil().getFilePath();
     _recorder = FlutterSoundRecorder();
     _player = FlutterSoundPlayer();
     _openAudioSession();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -457,7 +457,7 @@ packages:
     source: hosted
     version: "1.9.0"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: c9e7d3a4cd1410877472158bee69963a4579f78b68c65a2b7d40d1a7a88bb161

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   json_annotation: ^4.8.1
   uuid: ^4.4.0
 
+  path_provider: ^2.0.9
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
issue: #70 

구현 내용
---
- 대본 결과 retrofit api 구현
- 앱 내 로컬 파일을 읽고 쓰기 위한 path_provider 패키지 추가
- 파일 path 관리 및 controller에 api 연결
- 받아온 데이터 ui에 보여주기
- 측정 시간 ui에 표시
- multipart 파일 name 명시적으로 표시


기타
---
TT-196 음성 전송 및 연습 결과 api 연동

- 파일 전송하기
    - 참고자료
        - https://pub.dev/packages/retrofit
        - https://stackoverflow.com/questions/69507817/flutter-retrofit-upload-file
            
            ```jsx
            	@POST('http://httpbin.org/post')
              Future<void> createNewTaskFromFile(@Part() File file);
            ```
            
        - 다음과 같이 @Part() 어노테이션을 사용하여 파일을 전송할 수 있다.
        - @Multipart() 어노테이션도 달아야 한다는 말도 스택오버플로우에 있기는 하지만, 해봐야 알 듯 하다.
    - 오류가 발생했는데, 멀티 파트 통신 규약이 서로 안맞아서 생기는 오류일 것이라고 다른 소마 연수생분이 조언해주심. 로컬 서버로 앱을 연결해서 와이어샤크로 까보니 ‘name’ 부분이 서버에서 받는 이름은 media인데 앱에서는 ‘file’로 보내서 발생한 오류였음. 해결하기 위해 스택 오버플로우에 나온 방식대로 Part(name: ‘media’)로 시도해봤지만 해결되지 않아 서버에서 name 을 ‘file’로 받는 식으로 수정하여 해결함.
        - → 다음날 다시 해보니 Part(name: ‘media’) 잘 적용된다! 수정 후 dart run build_runner build 를 안해주고 핫리로드해서 생긴 문제같다.
        - 근데 이미 서버에서 수정하여 그냥 file로 가기로 함.

- **path_provider**
    - SharedPreferences는 작은 데이터(문자열, 숫자, 불리언 등)를 저장하는 데 적합하지만, 음성 파일과 같은 큰 데이터를 저장하는 데는 적합하지 않다. 따라서 path_provider를 사용했다.
    - 참고자료
        - https://pub.dev/packages/path_provider
    - 디바이스의 특정 디렉토리(예: 앱의 사설 디렉토리)에 접근하여 파일을 저장하고 읽을 수 있다.
    - 다음과 같이 패키지를 추가할 수 있다.
        
        ```jsx
        dependencies:
          path_provider: ^2.0.9
        ```
        
    - 다음과 같이 파일 경로를 가져올 수 있다.
        
        ```jsx
        import 'package:path_provider/path_provider.dart';
        
        Directory appDocDir = await getApplicationDocumentsDirectory();
        String appDocPath = appDocDir.path;
        String filePath = '$appDocPath/audio_recording.aac';
        File file = File(filePath);
        ```