### PR TITLE
TT-278 입력한 대본이 길 때 맨 끝까지 스크롤되지 않는 오류

### DIFF
--- a/lib/features/voice_recode/view/voice_recode_screen_with_script.dart
+++ b/lib/features/voice_recode/view/voice_recode_screen_with_script.dart
@@ -85,60 +85,65 @@ class _VoiceRecodeScreenWithScriptState extends State<VoiceRecodeScreenWithScrip
         ),
         body: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8),
-          child: ListView.builder(
+          child: CustomScrollView(
             key: _controller.scriptListViewKey,
             controller: _controller.scriptScrollController,
             physics: const NeverScrollableScrollPhysics(),
-            padding: const EdgeInsets.all(8),
-            itemCount: _controller.script?.length ?? 0,
-            itemBuilder: (BuildContext context, int index) {
-              return Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const SizedBox(height: 10,),
-                  Text(_controller.script?[index] ?? ''),
-                  if(index + 1 == _controller.script?.length)
-                    GetX<VoiceRecodeCtr>(
-                      builder: (_) => Container(
-                        height: _controller.scriptListViewSize.value,
-                        alignment: Alignment.center,
-                        child: _controller.practiceState.value == PracticeState.ENDRECODING
-                          ? Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              ElevatedButton(
-                                  onPressed: () { _controller.endPractice(context); },
-                                  child: const Text("분석 받기")
-                              ),
-                              IntrinsicWidth(
-                                child: ElevatedButton(
-                                    onPressed: () { _controller.startPracticeWithScript(); },
-                                    child: Row(
-                                      crossAxisAlignment: CrossAxisAlignment.end,
-                                      children: [
-                                        const Text("다시 녹음하기"),
-                                        _controller.maxAudioTime.value == null
-                                            ? const SizedBox(width: 10, height: 10, child: CircularProgressIndicator(strokeWidth: 1,))
-                                            : Text(
-                                          "(최대 ${_controller.maxAudioTime.value?.text ?? '?'})",
-                                          style: const TextStyle(
-                                            fontSize: 10,
-                                          ),
-                                        )
-                                      ],
-                                    )
-                                ),
-                              ),
-                            ],
-                          )
-                          : const Text(""),
-                      ),
-                    ),
-                ],
-              );
-            }
-          ),
-        ),
+            slivers: [
+              SliverList(
+                delegate: SliverChildBuilderDelegate(
+                      (BuildContext context, int index) {
+                        return Column(
+                          children: [
+                            const SizedBox(height: 10,),
+                            Text(_controller.script?[index] ?? ''),
+                          ],
+                        );
+                  },
+                  childCount: (_controller.script?.length ?? 0),
+                ),
+              ),
+              SliverToBoxAdapter(
+                child: GetX<VoiceRecodeCtr>(
+                  builder: (_) => Container(
+                    height: _controller.scriptListViewSize.value,
+                    alignment: Alignment.center,
+                    child: _controller.practiceState.value == PracticeState.ENDRECODING
+                        ? Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        ElevatedButton(
+                            onPressed: () { _controller.endPractice(context); },
+                            child: const Text("분석 받기")
+                        ),
+                        IntrinsicWidth(
+                          child: ElevatedButton(
+                              onPressed: () { _controller.startPracticeWithScript(); },
+                              child: Row(
+                                crossAxisAlignment: CrossAxisAlignment.end,
+                                children: [
+                                  const Text("다시 녹음하기"),
+                                  _controller.maxAudioTime.value == null
+                                      ? const SizedBox(width: 10, height: 10, child: CircularProgressIndicator(strokeWidth: 1,))
+                                      : Text(
+                                    "(최대 ${_controller.maxAudioTime.value?.text ?? '?'})",
+                                    style: const TextStyle(
+                                      fontSize: 10,
+                                    ),
+                                  )
+                                ],
+                              )
+                          ),
+                        ),
+                      ],
+                    )
+                        : const Text(""),
+                  ),
+                ),
+              ),
+            ],
+          )
+      ),
     );
   }
 }


### PR DESCRIPTION
issue:  #85

구현 내용
---
- 대본 내용을 보여주는 ui를 ListView.builder에서 CustomScrollView와 SliverList, SliverToBoxAdapter로 변경함.

기타
---
- `~~cacheExtent` 로 ListView가 보이지 않는 부분을 몇 픽셀까지 미리 랜더링할지를 설정할 수 있는데, 이 값을 1 이상으로만 해두면 (기본값은 0.0) ScrollContror가 최대 스크롤 범위를 제대로 인식할 수 있게 됨.~~ → 인 줄 알았는데 아님. cacheExtent를 2000정도로 주면 해결되긴 하는데, 근본적인 해결 방법이 아닌 것 같음.
- ListView의 itemCount 외에 추가로 마지막에 위젯을 추가해서 스크롤의 범위를 정확하게 인식하지 못하는 것 같음. 따라서 `CustomScrollView`와 `SliverList`, `SliverToBoxAdapter`를 사용하여 해결함.