### PR TITLE
TT-280 음성 길이 확인할 때 음성 재생되는 오류

### DIFF
--- a/lib/features/common/utils/recoding_file_util.dart
+++ b/lib/features/common/utils/recoding_file_util.dart
@@ -22,14 +22,11 @@ class RecodingFileUtil {
     return filePath;
   }
 
+  //TODO 이런식으로 구하는게 맞나?
   Future<Duration> getDuration() async {
     String path = await getFilePath();
     Duration? duration = await player.startPlayer(
       fromURI: path,
-      codec: Codec.defaultCodec,
-      whenFinished: () {
-        print('Finished playing');
-      },
     );
     player.stopPlayer();
     if(duration == null) throw Exception("[getDuration] duration is null!");

--- a/lib/features/common/utils/recoding_file_util.dart
+++ b/lib/features/common/utils/recoding_file_util.dart
@@ -31,6 +31,7 @@ class RecodingFileUtil {
         print('Finished playing');
       },
     );
+    player.stopPlayer();
     if(duration == null) throw Exception("[getDuration] duration is null!");
     print("[getDuration] duration: $duration");
     return duration;


### PR DESCRIPTION
issue: #87

구현 내용
---
- 녹음한 음성 파일을 분석할 때 음성 파일의 길이를 구하는데, 그때 음성 파일이 재생되는 문제가 있음. 음성 파일의 길이를 구할 때 음성 파일 player로 파일을 재생하기 때문에 생긴 오류였음. 재생을 실행하자마자 바로 재생을 중지하는 코드를 추가하여 해결함.