### PR TITLE
TT-294 연습 결과에서 시간 계산 유형 보이지 않게 하기

### DIFF
--- a/lib/features/practice_result/view/practice_result_screen.dart
+++ b/lib/features/practice_result/view/practice_result_screen.dart
@@ -5,7 +5,6 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get/get.dart';
 import 'package:swm_peech_flutter/features/practice_result/controller/practice_result_controller.dart';
-import 'package:swm_peech_flutter/features/practice_result/model/now_status.dart';
 import 'package:swm_peech_flutter/features/practice_result/widget/editing_dialog.dart';
 
 class PracticeResultScreen extends StatelessWidget {
@@ -56,34 +55,35 @@ class PracticeResultScreen extends StatelessWidget {
                                             fontWeight: FontWeight.bold
                                           ),
                                         ),
-                                        const SizedBox(width: 2,),
-                                        if(controller.practiceResult.value?.script?[index].nowStatus == NowStatus.realTime)
-                                          const Text(
-                                            "측정",
-                                            style: TextStyle(
-                                              fontSize: 9,
-                                              color: Colors.grey,
-                                              fontWeight: FontWeight.bold
-                                            ),
-                                          )
-                                        else if(controller.practiceResult.value?.script?[index].nowStatus == NowStatus.expectedTime)
-                                          const Text(
-                                            "예상",
-                                            style: TextStyle(
-                                                fontSize: 9,
-                                                color: Colors.grey,
-                                                fontWeight: FontWeight.bold
-                                            ),
-                                          )
-                                        else if(controller.practiceResult.value?.script?[index].nowStatus == NowStatus.realAndExpectedTime)
-                                            const Text(
-                                              "측정+예상",
-                                              style: TextStyle(
-                                                  fontSize: 9,
-                                                  color: Colors.grey,
-                                                  fontWeight: FontWeight.bold
-                                              ),
-                                            )
+                                        // TODO 빠른 데모 출시를 위해 임시로 숨김.
+                                        // const SizedBox(width: 2,),
+                                        // if(controller.practiceResult.value?.script?[index].nowStatus == NowStatus.realTime)
+                                        //   const Text(
+                                        //     "측정",
+                                        //     style: TextStyle(
+                                        //       fontSize: 9,
+                                        //       color: Colors.grey,
+                                        //       fontWeight: FontWeight.bold
+                                        //     ),
+                                        //   )
+                                        // else if(controller.practiceResult.value?.script?[index].nowStatus == NowStatus.expectedTime)
+                                        //   const Text(
+                                        //     "예상",
+                                        //     style: TextStyle(
+                                        //         fontSize: 9,
+                                        //         color: Colors.grey,
+                                        //         fontWeight: FontWeight.bold
+                                        //     ),
+                                        //   )
+                                        // else if(controller.practiceResult.value?.script?[index].nowStatus == NowStatus.realAndExpectedTime)
+                                        //     const Text(
+                                        //       "측정+예상",
+                                        //       style: TextStyle(
+                                        //           fontSize: 9,
+                                        //           color: Colors.grey,
+                                        //           fontWeight: FontWeight.bold
+                                        //       ),
+                                        //     )
                                       ],
                                     ),
                                     GestureDetector(


### PR DESCRIPTION
issue: #98

구현 내용
---
- 빠른 출시를 위해 시간 측정 유형에 따라 '예상', '측정', '예상+측정'이라고 표시하는 ui를 숨김처리함
