### PR TITLE
TT-296 결과 수정에서 input script id 대신 result script id 사용

### DIFF
--- a/lib/features/common/data_source/remote/remote_script_input_data_source.g.dart
+++ b/lib/features/common/data_source/remote/remote_script_input_data_source.g.dart
@@ -21,7 +21,7 @@ class _RemoteScriptInputDataSource implements RemoteScriptInputDataSource {
   String? baseUrl;
 
   @override
-  Future<ScriptIdModel> postScript(
+  Future<ScriptIdModel?> postScript(
     int themeId,
     Map<String, dynamic> body,
   ) async {
@@ -31,7 +31,7 @@ class _RemoteScriptInputDataSource implements RemoteScriptInputDataSource {
     final _data = <String, dynamic>{};
     _data.addAll(body);
     final _result = await _dio
-        .fetch<Map<String, dynamic>>(_setStreamType<ScriptIdModel>(Options(
+        .fetch<Map<String, dynamic>?>(_setStreamType<ScriptIdModel>(Options(
       method: 'POST',
       headers: _headers,
       extra: _extra,
@@ -47,7 +47,8 @@ class _RemoteScriptInputDataSource implements RemoteScriptInputDataSource {
               _dio.options.baseUrl,
               baseUrl,
             ))));
-    final value = ScriptIdModel.fromJson(_result.data!);
+    final value =
+        _result.data == null ? null : ScriptIdModel.fromJson(_result.data!);
     return value;
   }
 

--- a/lib/features/practice_result/model/paragraph_list_model.dart
+++ b/lib/features/practice_result/model/paragraph_list_model.dart
@@ -5,9 +5,13 @@ part 'paragraph_list_model.g.dart';
 
 @JsonSerializable()
 class ParagraphListModel {
+  int? scriptId;
+  //TODO 이거 하나 다른데 data model을 분리해야 할까? (클린 아키텍처로 dto와 vo를 분리하면 해결될 문제인 것 같은데, 지금 구조에서는 어떻게 해야 할까?)
+  String? totalRealTime;
+  String? totalTime;
   List<ParagraphModel>? script;
 
-  ParagraphListModel({required this.script});
+  ParagraphListModel({this.scriptId, this.totalRealTime, this.totalTime, this.script});
 
   factory ParagraphListModel.fromJson(Map<String, dynamic> json) => _$ParagraphListModelFromJson(json);
   Map<String, dynamic> toJson() => _$ParagraphListModelToJson(this);


### PR DESCRIPTION
issue: #100

구현 내용
---
- 수정된 api 스펙에 맞춰 data model 수정
- 수정된 결과 받아올 때, 유저에게 입력받은 대본의 id가 아닌 결과로 받은 id를 사용하도록 수정