### PR TITLE
TT-335 녹음 최대 시간 됐을 때 스크롤 중지되지 않음

### DIFF
--- a/lib/features/voice_recode/controller/voice_recode_controller.dart
+++ b/lib/features/voice_recode/controller/voice_recode_controller.dart
@@ -161,6 +161,7 @@ class VoiceRecodeCtr extends GetxController {
     // _stopRecodingWhenScrollIsEndListener()에 의해 자동으로 음성 녹음 중지
     // 스크롤 위치가 마지막으로 설정되어 _startAutoScrollingAnimation() 자동 종료
     _setScrollingToEnd();
+    _stopRecording();
   }
 
   void stopPracticeNoScript() {
@@ -171,6 +172,7 @@ class VoiceRecodeCtr extends GetxController {
   void _stopRecodingWhenScrollIsEndListener() {
     scriptScrollController.addListener(() {
       if(scriptScrollController.position.pixels == scriptScrollController.position.maxScrollExtent) {
+        _setScrollingToEnd();
         _stopRecording();
         scriptScrollController.removeListener(() { });
       }


### PR DESCRIPTION
issue: #112

구현 내용
---
- TT-335 녹음 최대 시간 됐을 때 녹음은 정지되지만 스크롤은 계속 되는 오류가 있음.
- 녹음 최대 시간이 됐을 때 스크롤을 맨 아래로 이동하도록 하여 해결함.
- 추가로 녹음 중지 버튼을 눌렀을 때 녹음 중지 함수도 명시적으로 호출하도록 함