### PR TITLE
TT-354 맨 처음 대본 없이 녹음했을 때 결과창에서 오류 발생

### DIFF
--- a/lib/features/practice_result/controller/practice_result_controller.dart
+++ b/lib/features/practice_result/controller/practice_result_controller.dart
@@ -84,9 +84,9 @@ class PracticeResultCtr extends GetxController {
      RemotePracticeResultDataSource practiceResultDataSource = RemotePracticeResultDataSource(dio);
      int seconds = await getRecodeSeconds();
      int themeId = getThemeId();
-     int? scriptId = LocalScriptStorage().getInputScriptId();
-     if(scriptId == null) throw Exception("[postPracticeResult] scriptId is null!");
      if(practiceMode == PracticeMode.withScript) {
+       int? scriptId = LocalScriptStorage().getInputScriptId();
+       if(scriptId == null) throw Exception("[postPracticeResult] scriptId is null!");
        File voiceFile = await getRecodingFile();
        ParagraphListModel paragraphListModel = await practiceResultDataSource.getPracticeWithScriptResultList(themeId, scriptId, voiceFile, seconds);
        return paragraphListModel;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.4+5
+version: 1.0.5+6
 
 environment:
   sdk: '>=3.3.4 <4.0.0'


### PR DESCRIPTION
issue: #144

구현 내용
---
- 앱을 맨 처음 깔았을 때 대본 입력하고 시작을 하기 전에 대본 없이 시작을 하면 오류 발생
- 입력되지 않은 scripId를 불러오려 해서 발생한 오류였음. 대본 있이 시작한 경우에만 scriptId를 불러오도록 해서 해결함.
- 빌드 버전 업