### PR TITLE
TT-386 access token refresh error

### DIFF
--- a/lib/features/common/controllers/social_login_controller.dart
+++ b/lib/features/common/controllers/social_login_controller.dart
@@ -41,7 +41,7 @@ class SocialLoginCtr extends GetxController {
     if (await isKakaoTalkInstalled()) {
       try {
         OAuthToken token = await UserApi.instance.loginWithKakaoTalk();
-        print("토큰: ${token.accessToken}");
+        print("KAKAO AccessToken: ${token.accessToken}");
         SocialLoginInfo kakaoLoginInfo = SocialLoginInfo(socialToken: token.accessToken, authorizationServer: 'KAKAO');
         AuthTokenResponseModel authTokenResponseModel = await postSocialToken(kakaoLoginInfo);
         loginChoiceViewState.value = SocialLoginChoiceViewState.success;

--- a/lib/features/common/data_source/remote/remote_auth_token_refresh_data_source.dart
+++ b/lib/features/common/data_source/remote/remote_auth_token_refresh_data_source.dart
@@ -9,7 +9,7 @@ part 'remote_auth_token_refresh_data_source.g.dart';
 abstract class RemoteAuthTokenRefreshDataSource {
   factory RemoteAuthTokenRefreshDataSource(Dio dio, {String baseUrl}) = _RemoteAuthTokenRefreshDataSource;
 
-  @retrofit.PATCH("/api/v1.1/auth/reissue")
+  @retrofit.POST("/api/v1.1/auth/reissue")
   @retrofit.Headers({'refreshToken': 'true'})
   Future<AuthTokenModel> refreshToken(@retrofit.Body() Map<String, dynamic> socialLoginInfo);
 }

--- a/lib/features/common/data_source/remote/remote_auth_token_refresh_data_source.dart
+++ b/lib/features/common/data_source/remote/remote_auth_token_refresh_data_source.dart
@@ -9,6 +9,7 @@ part 'remote_auth_token_refresh_data_source.g.dart';
 abstract class RemoteAuthTokenRefreshDataSource {
   factory RemoteAuthTokenRefreshDataSource(Dio dio, {String baseUrl}) = _RemoteAuthTokenRefreshDataSource;
 
-  @retrofit.POST("/api/v1.1/user")
+  @retrofit.PATCH("/api/v1.1/auth/reissue")
+  @retrofit.Headers({'refreshToken': 'true'})
   Future<AuthTokenModel> refreshToken(@retrofit.Body() Map<String, dynamic> socialLoginInfo);
 }

--- a/lib/features/common/dio_intercepter/auth_token_inject_interceptor.dart
+++ b/lib/features/common/dio_intercepter/auth_token_inject_interceptor.dart
@@ -16,7 +16,17 @@ class AuthTokenInjectInterceptor extends Interceptor {
         token = 'x';
       }
       options.headers.addAll({"authorization": "Bearer $token"});
-      print("[REQ] [TokenInject] [${options.method}] [${options.path}] -> inject token [$token]");
+      print("[REQ] [TokenInject] [${options.method}] [${options.path}] -> inject access token [$token]");
+    }
+
+    if(options.headers['refreshToken'] == 'true') {
+      options.headers.remove('refreshToken');
+      String? token = localAuthTokenStorage.getRefreshToken();
+      if(token == '' || token == null) {
+        token = 'x';
+      }
+      options.headers.addAll({"authorization": "Bearer $token"});
+      print("[REQ] [TokenInject] [${options.method}] [${options.path}] -> inject refresh token [$token]");
     }
 
     return super.onRequest(options, handler);

--- a/lib/features/common/dio_intercepter/auth_token_refresh_interceptor.dart
+++ b/lib/features/common/dio_intercepter/auth_token_refresh_interceptor.dart
@@ -22,6 +22,12 @@ class AuthTokenRefreshInterceptor extends Interceptor {
     final isStatus410 = err.response?.statusCode == 410;
 
     if(isStatus410) {
+
+      if(err.requestOptions.headers['noRefresh'] == 'true') {
+        print('[AuthTokenRefreshInterceptor] noRefresh');
+        return handler.reject(err);
+      }
+
       try {
         //refresh token 가져오기
         String refreshToken = localAuthTokenStorage.getRefreshToken() ?? "";
@@ -43,6 +49,7 @@ class AuthTokenRefreshInterceptor extends Interceptor {
         //다시 원래 요청으로 결과 받아오기
         final options = err.requestOptions;
         final reDio = AuthDioFactory().dio;
+        reDio.options.headers.addAll({'noRefresh': 'true'});
         final response = await reDio.fetch(options);
         print('다시 원래 요청으로 결과 받아오기 성공: ${response.data}');
         return handler.resolve(response);

--- a/lib/features/common/dio_intercepter/auth_token_refresh_interceptor.dart
+++ b/lib/features/common/dio_intercepter/auth_token_refresh_interceptor.dart
@@ -29,6 +29,8 @@ class AuthTokenRefreshInterceptor extends Interceptor {
           throw Exception("refreshToken is null!");
         }
 
+        print('refresh token 가져오기 성공: $refreshToken');
+
         //토큰 재발급받기
         RefreshTokenModel refreshTokenModel = RefreshTokenModel(refreshToken: refreshToken);
         RemoteAuthTokenRefreshDataSource remoteAuthTokenRefreshDataSource = RemoteAuthTokenRefreshDataSource(AuthDioFactory().dio);
@@ -36,10 +38,13 @@ class AuthTokenRefreshInterceptor extends Interceptor {
         LocalAuthTokenStorage().setAccessToken(authTokenModel.accessToken ?? '');
         LocalAuthTokenStorage().setRefreshToken(authTokenModel.refreshToken ?? '');
 
+        print('토큰 재발급 성공: ${authTokenModel.accessToken}');
+
         //다시 원래 요청으로 결과 받아오기
         final options = err.requestOptions;
         final reDio = AuthDioFactory().dio;
         final response = await reDio.fetch(options);
+        print('다시 원래 요청으로 결과 받아오기 성공: ${response.data}');
         return handler.resolve(response);
 
       } on DioException catch(e) {


### PR DESCRIPTION
issue: #164

구현 내용
---
- 토큰 refresh시 refresh token 넣어주는 로직 추가
- 수정된 api 스펙에 따라 token refresh method를 PATCH -> POST로 변경
- 토큰 refresh 반복 호출 안되도록 수정
- 재요청은 한번만 보내도록 설정
- 재요청 보낼때 이전 토큰을 그대로 보내던 문제 해결
