### PR TITLE
앱 available 직관적으로 수정

### DIFF
--- a/lib/features/common/controllers/app_info_controller.dart
+++ b/lib/features/common/controllers/app_info_controller.dart
@@ -75,7 +75,7 @@ class AppInfoController extends GetxController {
   }
 
   Future<bool> checkAppAvailable(BuildContext context) async {
-    if(appAvailable == true) {
+    if(appAvailable == false) {
       if(context.mounted) {
         showCommonDialog(
             context: context,


### PR DESCRIPTION
issue: #167

구현 내용
---
- available이 true일 때 앱 사용 불가를 띄우고 있는데, false일 때가 더 직관적이라고 생각하여 변경함