### PR TITLE
TT-408 녹음 recoder 닫혔을 때 이어하기 버튼 비활성화 #188

### DIFF
--- a/lib/features/voice_recode/controller/voice_recode_controller.dart
+++ b/lib/features/voice_recode/controller/voice_recode_controller.dart
@@ -41,6 +41,8 @@ class VoiceRecodeCtr extends GetxController {
   Rx<String?> promptSelectedOption = RxString('대본');
   final List<String> promptOptions = ['대본', '핵심 키워드', '전부 숨기기'];
 
+  Rx<bool> isRecordStopped = false.obs;
+
   @override
   void onInit() async {
     script = LocalScriptStorage().getInputScriptContent();
@@ -278,10 +280,18 @@ class VoiceRecodeCtr extends GetxController {
   }
 
   Future<void> _pauseRecoding() async {
+    if (_recorder?.isStopped ?? true) {
+      throw Exception("[_pauseRecoding] can't pause recorder. recorder is stopped");
+      return;
+    }
     await _recorder?.pauseRecorder();
   }
 
   Future<void> _resumeRecoding() async {
+    if (_recorder?.isStopped ?? true) {
+      throw Exception("[_resumeRecoding] can't resume recorder. recorder is stopped");
+      return;
+    }
     await _recorder?.resumeRecorder();
   }
 
@@ -290,23 +300,66 @@ class VoiceRecodeCtr extends GetxController {
     scriptScrollController.jumpTo(scriptScrollController.offset);
   }
 
-  void pausePracticeWithScript() async {
-    await _pauseRecoding();
+  void pausePracticeWithScript(BuildContext context) async {
+    try {
+      await _pauseRecoding();
+    } catch (e) {
+      if (context.mounted) {
+        showCommonDialog(
+          context: context,
+          title: '중단할 수 없습니다',
+          message: '녹음이 종료되어 녹음을 중단할 수 없습니다',
+          showFirstButton: false,
+          secondButtonText: '확인',
+          isSecondButtonToClose: true,
+        );
+      }
+      rethrow;
+    }
     _stopScrollingAnimation();
     recodingStopWatch.value.stop(); // 타이머 멈추기
     _timer?.cancel(); // 타이머 객체 취소
     practiceState.value = PracticeState.pause;
   }
 
-  void pausePracticeNoScript() async {
-    await _pauseRecoding();
+  void pausePracticeNoScript(BuildContext context) async {
+    try {
+      await _pauseRecoding();
+    } catch (e) {
+      if (context.mounted) {
+        showCommonDialog(
+          context: context,
+          title: '중단할 수 없습니다',
+          message: '녹음이 종료되어 녹음을 중단할 수 없습니다',
+          showFirstButton: false,
+          secondButtonText: '확인',
+          isSecondButtonToClose: true,
+        );
+      }
+      rethrow;
+    }
     recodingStopWatch.value.stop(); // 타이머 멈추기
     _timer?.cancel(); // 타이머 객체 취소
     practiceState.value = PracticeState.pause;
   }
 
-  void resumePracticeWithScript() async {
-    await _resumeRecoding();
+  void resumePracticeWithScript(BuildContext context) async {
+    try {
+      await _resumeRecoding();
+    } catch (e) {
+      if (context.mounted) {
+        showCommonDialog(
+          context: context,
+          title: '이어할 수 없습니다',
+          message: '녹음이 종료되어 이어서 녹음할 수 없습니다',
+          showFirstButton: false,
+          secondButtonText: '확인',
+          isSecondButtonToClose: true,
+        );
+      }
+      rethrow;
+    }
+
     recodingStopWatch.value.start(); // 타이머 멈추기
     _startTimer();
     int remainingTime = _getTotalExpectedTime() - recodingStopWatch.value.elapsedMilliseconds;
@@ -314,8 +367,22 @@ class VoiceRecodeCtr extends GetxController {
     practiceState.value = PracticeState.recoding;
   }
 
-  void resumePracticeNoScript() async {
-    await _resumeRecoding();
+  void resumePracticeNoScript(BuildContext context) async {
+    try {
+      await _resumeRecoding();
+    } catch (e) {
+      if (context.mounted) {
+        showCommonDialog(
+          context: context,
+          title: '이어할 수 없습니다',
+          message: '녹음이 종료되어 이어서 녹음할 수 없습니다',
+          showFirstButton: false,
+          secondButtonText: '확인',
+          isSecondButtonToClose: true,
+        );
+      }
+      rethrow;
+    }
     recodingStopWatch.value.start(); // 타이머 멈추기
     _startTimer();
     practiceState.value = PracticeState.recoding;

--- a/lib/features/voice_recode/view/voice_recode_screen_no_script.dart
+++ b/lib/features/voice_recode/view/voice_recode_screen_no_script.dart
@@ -31,7 +31,7 @@ class _VoiceRecodeScreenNoScriptState extends State<VoiceRecodeScreenNoScript> w
   void didChangeAppLifecycleState(AppLifecycleState state) {
     // 앱 백그라운드로 전환
     if (state == AppLifecycleState.paused) {
-      _controller.pausePracticeNoScript();
+      _controller.pausePracticeNoScript(context);
     }
   }
 
@@ -109,7 +109,7 @@ class _VoiceRecodeScreenNoScriptState extends State<VoiceRecodeScreenNoScript> w
                                 child: ColoredButton(
                                     text: '중지하기',
                                     onPressed: () {
-                                      _controller.pausePracticeNoScript();
+                                      _controller.pausePracticeNoScript(context);
                                     }),
                               ),
                             ],
@@ -184,7 +184,7 @@ class _VoiceRecodeScreenNoScriptState extends State<VoiceRecodeScreenNoScript> w
                                 child: ColoredButton(
                                     text: '이어하기',
                                     onPressed: () {
-                                      _controller.resumePracticeNoScript();
+                                      _controller.resumePracticeNoScript(context);
                                     }),
                               ),
                               const SizedBox(

--- a/lib/features/voice_recode/view/voice_recode_screen_with_script.dart
+++ b/lib/features/voice_recode/view/voice_recode_screen_with_script.dart
@@ -31,7 +31,7 @@ class _VoiceRecodeScreenWithScriptState extends State<VoiceRecodeScreenWithScrip
   void didChangeAppLifecycleState(AppLifecycleState state) {
     // 앱 백그라운드로 전환
     if (state == AppLifecycleState.paused) {
-      _controller.pausePracticeWithScript();
+      _controller.pausePracticeWithScript(context);
     }
   }
 
@@ -220,7 +220,7 @@ class _VoiceRecodeScreenWithScriptState extends State<VoiceRecodeScreenWithScrip
                                   child: ColoredButton(
                                       text: '중지하기',
                                       onPressed: () {
-                                        _controller.pausePracticeWithScript();
+                                        _controller.pausePracticeWithScript(context);
                                       }),
                                 ),
                               ],
@@ -295,7 +295,7 @@ class _VoiceRecodeScreenWithScriptState extends State<VoiceRecodeScreenWithScrip
                                   child: ColoredButton(
                                       text: '이어하기',
                                       onPressed: () {
-                                        _controller.resumePracticeWithScript();
+                                        _controller.resumePracticeWithScript(context);
                                       }),
                                 ),
                                 const SizedBox(


### PR DESCRIPTION
issue: #188 

구현 내용
---
- 녹음 recoder가 close됐을 때 ios에서 이어하기 버튼을 누르면 앱이 멈추는 버그가 있음. android와 web에서는 버튼이 작동하지는 않지만 앱이 정지하지는 않음. 오류를 방지하기 위해 recoder가 close된 상태면 이어하기 및 일시정지 버튼이 작동하지 않도록 함.