### PR TITLE
android html 빌드 오류

### DIFF
--- a/lib/initializer/firebase_initializer.dart
+++ b/lib/initializer/firebase_initializer.dart
@@ -1,7 +1,7 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:swm_peech_flutter/firebase_options.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
-import 'package:firebase_analytics_web/firebase_analytics_web.dart';
+//import 'package:firebase_analytics_web/firebase_analytics_web.dart'; //TODO GA for web, but not working. and make html error on android
 
 class FirebaseInitializer {
   Future<void> initialize() async {


### PR DESCRIPTION
issue: #204

구현 내용
---
- 안드로이드에서 web GA설정을 위해 넣었던 `import 'package:firebase_analytics_web/firebase_analytics_web.dart';` 가 html 에러를 일으킴 (웹에서만 사용 가능한 html 라이브러리를 앱에서 import할 때 발생하는 에러)
- 해당 import를 주석처리함 (web GA를 위해 넣었던 import지만, web GA가 작동하지 않아서 일단 주석처리)